### PR TITLE
chore(bundle): add webpack-node-externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   "devDependencies": {
     "@angular/common": "^2.0.0",
     "@angular/compiler": "^2.0.0",
-    "@angular/compiler-cli": "2.0.0",
+    "@angular/compiler-cli": "^2.0.0",
     "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0",
     "@angular/http": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
@@ -88,6 +89,7 @@
     "validate-commit-msg": "~2.8.0",
     "webpack": "~1.13.0",
     "webpack-dev-server": "~1.16.1",
+    "webpack-node-externals": "^1.5.4",
     "zone.js": "~0.6.12"
   },
   "peerDependencies": {

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const nodeExternals = require('webpack-node-externals');
+
 module.exports = {
   entry: './src/index.ts',
   output: {
@@ -6,74 +10,7 @@ module.exports = {
     libraryTarget: 'umd',
     library: 'ng2-restangular'
   },
-  externals: {
-    '@angular/core': {
-      root: ['ng', 'core'],
-      commonjs: '@angular/core',
-      commonjs2: '@angular/core',
-      amd: '@angular/core'
-    },
-    '@angular/common': {
-      root: ['ng', 'common'],
-      commonjs: '@angular/common',
-      commonjs2: '@angular/common',
-      amd: '@angular/common'
-    },
-    'rxjs/Subject': {
-      root: ['rx', 'Subject'],
-      commonjs: 'rxjs/Subject',
-      commonjs2: 'rxjs/Subject',
-      amd: 'rxjs/Subject'
-    },
-    'rxjs/Observable': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/Observable',
-      commonjs2: 'rxjs/Observable',
-      amd: 'rxjs/Observable'
-    },
-    'rxjs/observable/merge': {
-      root: ['rx', 'Observable', 'merge'],
-      commonjs: 'rxjs/observable/merge',
-      commonjs2: 'rxjs/observable/merge',
-      amd: 'rxjs/observable/merge'
-    },
-    'rxjs/add/operator/map': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/add/operator/map',
-      commonjs2: 'rxjs/add/operator/map',
-      amd: 'rxjs/add/operator/map'
-    },
-    'rxjs/add/operator/mergeMap': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/add/operator/mergeMap',
-      commonjs2: 'rxjs/add/operator/mergeMap',
-      amd: 'rxjs/add/operator/mergeMap'
-    },
-    'rxjs/add/operator/takeUntil': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/add/operator/takeUntil',
-      commonjs2: 'rxjs/add/operator/takeUntil',
-      amd: 'rxjs/add/operator/takeUntil'
-    },
-    'rxjs/add/operator/filter': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/add/operator/filter',
-      commonjs2: 'rxjs/add/operator/filter',
-      amd: 'rxjs/add/operator/filter'
-    },
-    'rxjs/add/operator/pairwise': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/add/operator/pairwise',
-      commonjs2: 'rxjs/add/operator/pairwise',
-      amd: 'rxjs/add/operator/pairwise'
-    },
-    'rxjs/add/operator/take': {
-      root: ['rx', 'Observable'],
-      commonjs: 'rxjs/add/operator/take',
-      commonjs2: 'rxjs/add/operator/take',
-      amd: 'rxjs/add/operator/take'
-    }
-  },
+  externals: [nodeExternals()],
   devtool: 'source-map',
   module: {
     preLoaders: [{


### PR DESCRIPTION
Weback umd output is contains lot of unnecessary dependency.

Original webpack output:
```
Time: 5824ms
                   Asset     Size  Chunks             Chunk Names
    ./ng2-restangular.js  1.32 MB       0  [emitted]  main
./ng2-restangular.js.map  1.62 MB       0  [emitted]  main

```

New webpack output:
```
Time: 4684ms
                   Asset     Size  Chunks             Chunk Names
    ./ng2-restangular.js  66.4 kB       0  [emitted]  main
./ng2-restangular.js.map   112 kB       0  [emitted]  main
```
