### PR TITLE
fix(response): Check error response before parsing

### DIFF
--- a/src/ng2-restangular-http.ts
+++ b/src/ng2-restangular-http.ts
@@ -33,7 +33,7 @@ export class RestangularHttp {
       return response;
     })
     .catch(err => {
-      err.data = typeof err._body == 'string' ? JSON.parse(err._body) : err._body;
+      err.data = typeof err._body == 'string' && err._body.length > 0 ? JSON.parse(err._body) : err._body;
       err.request = request;
       err.repeatRequest = (newRequest?) => {
         return this.request(newRequest || request);


### PR DESCRIPTION
Add check for error response string length and prevent parsing empty string that is causes of Exception from JSON.parse()