### PR TITLE
Fix URLSearchParams for query params of type Array

### DIFF
--- a/src/ng2-restangular-helper.ts
+++ b/src/ng2-restangular-helper.ts
@@ -26,10 +26,18 @@ export class RestangularHelper {
     
     for (let key in requestQueryParams) {
       let value: any = requestQueryParams[key];
-      if (typeof value === 'object') {
-        value = JSON.stringify(value);
+
+      if (Array.isArray(value)) {
+        value.forEach(function(val){
+          search.append(key, val);
+        });
+      } else {
+        if (typeof value === 'object') {
+          value = JSON.stringify(value);
+        }
+        search.append(key, value);
       }
-      search.append(key, value);
+           
     }
     
     return search;


### PR DESCRIPTION
There was an issue regarding how query parameters of type array were set into URLSearchParams.
According to what I understand, URLSearchParams is expecting array params to be set likewise:
`urlSearchParams.append('key','val1');
urlSearchParams.append('key','val2');
...
urlSearchParams.append('key','valN'); `

In order to provide some query string which looks like:

> ?key=val1&key=val2...&key=valN

This would match Restangular1's behavior.