### PR TITLE
Rename UMD build product to `ngx-restangular` (to match `package.json`)

### DIFF
--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -6,9 +6,9 @@ module.exports = {
   entry: './src/index.ts',
   output: {
     path: __dirname + '/dist/umd',
-    filename: './ng2-restangular.js',
+    filename: './ngx-restangular.js',
     libraryTarget: 'umd',
-    library: 'ng2-restangular'
+    library: 'ngx-restangular'
   },
   externals: [nodeExternals()],
   devtool: 'source-map',


### PR DESCRIPTION
It is impossible at the moment to `import * from 'ngx-restangular'` on Angular 4 and Nativescript 3 because `./dist/umd/ng2-restangular.js` file name produced by Webpack does not match `"main": "./dist/umd/ngx-restangular.js",` property of `package.json`.