### PR TITLE
Set the responseType

### DIFF
--- a/src/ngx-restangular-helper.ts
+++ b/src/ngx-restangular-helper.ts
@@ -14,6 +14,7 @@ export class RestangularHelper {
       search: requestQueryParams,
       url: options.url,
       body: options.data,
+      responseType: options.responseType,
       withCredentials
     });
     


### PR DESCRIPTION
Hello, 

To download a file, the responseType is being ignored. Thererfore the responded data is handled as a String, with the normal JSON parsing. In a response with blob data I get an error because it is trying to parse the data as JSON. In adding the responseType
in the createRequestOptions method of RestangularHelper :
`
let requestOptions = new RequestOptions({
      method: RequestMethod[methodName],
      headers: requestHeaders,
      search: requestQueryParams,
      url: options.url,
      body: options.data,
      responseType: options.responseType,
      withCredentials
    });
`
the bug is fixed. We just need to set the reponseType of a request like this :
`
this.restangular.oneUrl('file/').withHttpConfig({responseType: ResponseContentType.Blob}).get( ) .subscribe(data => { this.downloadFileInternal(data) });
`