### PR TITLE
Update to Angular 10

### DIFF
--- a/projects/ngx-restangular/src/lib/ngx-restangular.module.ts
+++ b/projects/ngx-restangular/src/lib/ngx-restangular.module.ts
@@ -19,9 +19,9 @@ export class RestangularModule {
     }
   }
 
-  static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
-  static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
-  static forRoot(config1?, config2?): ModuleWithProviders {
+  static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders<any>;
+  static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders<any>;
+  static forRoot(config1?, config2?): ModuleWithProviders<any> {
     return {
       ngModule: RestangularModule,
       providers: [


### PR DESCRIPTION
After updating to angular 10 I got these Problems

ERROR in node_modules/ngx-restangular/lib/ngx-restangular.module.d.ts:5:78 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).

5     static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
                                                                               ~~~~~~~~~~~~~~~~~~~
node_modules/ngx-restangular/lib/ngx-restangular.module.d.ts:6:97 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).

6     static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;