### PR TITLE
Fix Ivy compatibility issue in Angular 10

### DIFF
--- a/projects/ngx-restangular/src/lib/ngx-restangular.module.ts
+++ b/projects/ngx-restangular/src/lib/ngx-restangular.module.ts
@@ -19,8 +19,8 @@ export class RestangularModule {
     }
   }
 
-  static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
-  static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
+  static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders<RestangularModule>;
+  static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders<RestangularModule>;
   static forRoot(config1?, config2?): ModuleWithProviders {
     return {
       ngModule: RestangularModule,


### PR DESCRIPTION
ERROR in node_modules/ngx-restangular/lib/ngx-restangular.module.d.ts:8:97 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).

ngcc cannot resolve this automatically so code change is required.