### PR TITLE
- Fix ModuleWithProviders is not generic error

### DIFF
--- a/projects/ngx-restangular/src/lib/ngx-restangular.module.ts
+++ b/projects/ngx-restangular/src/lib/ngx-restangular.module.ts
@@ -19,14 +19,14 @@ export class RestangularModule {
     }
   }
 
-  static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
-  static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders;
-  static forRoot(config1?, config2?): ModuleWithProviders {
+  static forRoot(configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders<RestangularModule>;
+  static forRoot(providers?: any[], configFunction?: (provider: any, ...arg: any[]) => void): ModuleWithProviders<RestangularModule>;
+  static forRoot(config1?, config2?): ModuleWithProviders<RestangularModule> {
     return {
       ngModule: RestangularModule,
       providers: [
-        {provide: CONFIG_OBJ, useValue: [config1, config2]},
-        {provide: RESTANGULAR, useFactory: RestangularFactory, deps: [CONFIG_OBJ]},
+        { provide: CONFIG_OBJ, useValue: [config1, config2] },
+        { provide: RESTANGULAR, useFactory: RestangularFactory, deps: [CONFIG_OBJ] },
       ]
     };
   }


### PR DESCRIPTION
Some Angular users are getting ModuleWithProviders is not a generic error. As typescript gives error in build for type error in RestangularModule.